### PR TITLE
chore: override base:config ignorePaths

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,11 @@
   "schedule": ["before 07:00 on Thursday"],
   "configMigration": true,
   "ignorePresets": ["group:monorepos"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**"
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Description
The default config inherited from `config:base`, sets [`:ignoreModulesAndTests`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) which contains these paths:

```json
{
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ]
}
```
which excludes some of our test projects. We do want Renovate to update test projects as well, so we need to override this config.

I would also assume if we have any examples or fixtures with dependencies, we would want those updated as well.
