### PR TITLE
Migrate renovate config

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "description": "Groups minor and patch updates together in a single PR, and treat NPM 0.x.x updates as major updates.",
   "minimumReleaseAge": "3 days",
   "timezone": "Europe/Oslo",

--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "description": "Groups minor and patch updates together in a single PR, and treat NPM 0.x.x updates as major updates.",
-  "stabilityDays": 3,
+  "minimumReleaseAge": "3 days",
   "timezone": "Europe/Oslo",
   "internalChecksFilter": "strict",
   "schedule": ["before 07:00 on Thursday"],


### PR DESCRIPTION
Renovate has migrated the stabilityDays to minimumReleaseAge ref: https://docs.renovatebot.com/configuration-options/#minimumreleaseage

config:base is the old name for config:recomended ref: https://github.com/renovatebot/renovate/discussions/24071#discussioncomment-6823727

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
