### PR TITLE
Update deprecated and removed config uption

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,7 +23,7 @@
         "nuget"
       ],
       "groupName": "{{manager}} non-major dependencies",
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupSlug": "{{manager}}-minor-patch"
     },
@@ -31,7 +31,7 @@
       "matchManagers": ["npm"],
       "groupName": "npm non-major dependencies",
       "matchCurrentVersion": ">=1.0.0",
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupSlug": "npm-minor-patch"
     }


### PR DESCRIPTION
While creating custom rules for our repo I discovered that renovate has changed one of its configuration fields

https://docs.renovatebot.com/configuration-options/#matchpackagenames