### PR TITLE
Only rebase when branch is conflicted

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
   "schedule": ["before 07:00 on Thursday"],
   "configMigration": true,
   "ignorePresets": ["group:monorepos"],
+  "rebaseWhen": "conflicted",
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",


### PR DESCRIPTION
Configure renovate to only rebase when the branch is conflicted. https://docs.renovatebot.com/configuration-options/#rebasewhen